### PR TITLE
7z forces to extract when the same file already exists.

### DIFF
--- a/rake/extracttask.rb
+++ b/rake/extracttask.rb
@@ -71,7 +71,7 @@ end
 
 def seven_zip_get(source, item, target)
   puts "** Extracting '#{item}' from '#{source}' into '#{target}'" if Rake.application.options.trace
-  sh "\"#{RubyInstaller::SEVEN_ZIP}\" e \"#{source}\" -o\"#{target}\" \"#{item}\" > NUL 2>&1"
+  sh "\"#{RubyInstaller::SEVEN_ZIP}\" e -y \"#{source}\" -o\"#{target}\" \"#{item}\" > NUL 2>&1"
 end
 
 def seven_zip_build(source, target, options={})


### PR DESCRIPTION
Rake may block without this patch because RubyInstaller 7z output to
NUL. Users will not notice a prompt from 7z.
