### PR TITLE
Rubygems

### DIFF
--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -275,8 +275,8 @@ module RubyInstaller
 
     RubyGems = OpenStruct.new(
       :release => 'official',
-      :version => '1.7.2',
-      :url => 'http://rubyforge.org/frs/download.php/74619',
+      :version => '1.8.11',
+      :url => 'http://production.cf.rubygems.org/rubygems',
       :checkout => 'http://github.com/rubygems/rubygems.git',
       :checkout_target => 'downloads/rubygems',
       :target => 'sandbox/rubygems',
@@ -285,7 +285,7 @@ module RubyInstaller
         '--no-rdoc'
       ],
       :files => [
-        'rubygems-1.7.2.tgz'
+        'rubygems-1.8.11.tgz'
       ],
       :hooks => [
         'resources/rubygems/operating_system.rb'


### PR DESCRIPTION
Hello,

I just used your very excellent rubyinstaller code to build a debug 1.9.3 version. I ran into an issue using rubygems 1.7.2 during the build (a NameError around Deprecate? I should have saved it) so I changed the build to use 1.8.11. After that my build was successful. Not sure if you're interested in this put I thought you might be.

If you'd like me to reproduce the error I'd be more than happy to.
Thanks again -
Luke
