### PR TITLE
RubyGems pre_install hook now uses require 'devkit'

### DIFF
--- a/resources/devkit/dk.rb.erb
+++ b/resources/devkit/dk.rb.erb
@@ -49,14 +49,7 @@ EOT
 # #{DEVKIT_START} override 'gem install' to enable RubyInstaller DevKit usage
 Gem.pre_install do |gem_installer|
   unless gem_installer.spec.extensions.empty?
-    unless ENV['PATH'].include?('#{d}\\\\mingw\\\\bin') then
-      Gem.ui.say 'Temporarily enhancing PATH to include DevKit...' if Gem.configuration.verbose
-      ENV['PATH'] = '#{d}\\\\bin;#{d}\\\\mingw\\\\bin;' + ENV['PATH']
-    end
-    ENV['RI_DEVKIT'] = '#{d}'
-<% tool_names.each_pair do |k,v| -%>
-    <%= 'ENV[\'%s\'] = \'%s\'' % [k,v] %>
-<% end -%>
+    require 'devkit'
   end
 end
 # #{DEVKIT_END}


### PR DESCRIPTION
Use `require 'devkit'` in `operating_system.rb` instead of duplicating the code that is already defined in `devkit.rb`

Original conception from:

https://groups.google.com/d/msg/rubyinstaller/39-GKsIC5mw/Kj24coVS6Q0J
