### PR TITLE
Moved DevKit Environment message to Gem Hook

### DIFF
--- a/resources/devkit/dk.rb.erb
+++ b/resources/devkit/dk.rb.erb
@@ -48,9 +48,7 @@ EOT
 <<-EOT
 # #{DEVKIT_START} override 'gem install' to enable RubyInstaller DevKit usage
 Gem.pre_install do |gem_installer|
-  unless gem_installer.spec.extensions.empty?
-    require 'devkit'
-  end
+    load 'devkit.rb' unless gem_installer.spec.extensions.empty?
 end
 # #{DEVKIT_END}
 EOT


### PR DESCRIPTION
Also fixed bug introduced in f9bdde3b81d7de9cff440c0afc1328e0b4a7dc2b that wouldn't allow multiple gems that had Native Extensions and required Devkit to install them.

_Hint: If `Gem.pre_install` evalutes to `false` the installation fails._
