### PR TITLE
Copy openssl.cnf to the default path for test-all

### DIFF
--- a/recipes/dependencies/knapsack.rake
+++ b/recipes/dependencies/knapsack.rake
@@ -29,7 +29,24 @@ dependencies.each do |dependency_key, dependency|
       end
       task :extract => [:extract_utils, :download, dependency.target, et]
 
-      task :activate => [:extract] do
+      task :patch => [:extract] do
+        if dependency_key == 'openssl'
+          openssl_base = File.join(RubyInstaller::ROOT, dependency.target)
+          conf_file = File.join(openssl_base, "include/openssl/opensslconf.h")
+          content = File.open(conf_file, "rb") { |f| f.read }
+
+          if content
+            ssl_dir = content.sub(/.*\n#define OPENSSLDIR "([^\n]*)"\n.*/m, '\1')
+          end
+
+          if ssl_dir && !File.exist?(File.join(ssl_dir, "openssl.cnf"))
+            mkdir_p ssl_dir
+            cp File.join(openssl_base, "ssl/openssl.cnf"), ssl_dir
+          end
+        end
+      end
+
+      task :activate => [:extract, :patch] do
         puts "Activating #{dependency.human_name} version #{dependency.version}"
         activate(dependency.target)
       end


### PR DESCRIPTION
The default path of openssl.cnf is determined when openssl configure.

Here are openssl configure options for configration file path.

```
  --prefix=DIR  Install in DIR/bin, DIR/lib, DIR/include/openssl.
                Configuration files used by OpenSSL will be in DIR/ssl
                or the directory specified by --openssldir.

  --openssldir=DIR Directory for OpenSSL files. If no prefix is specified,
                the library files and binaries are also installed there.
```

Copying openssl.cnf to the path will fix a failure of ruby test-all
OpenSSL::TestConfig#test_constants.

Related post:
https://groups.google.com/d/msg/rubyinstaller/CjP3BMpoEpE/fRE2gYC4jZ0J

Now openssl.cnf path of knapsack is C:\Users\Luis\Projects\oss\knapsack.old\knap-build\var\knapsack\software\x86-windows\openssl\1.0.0j\ssl\openssl.cnf.
Perhaps it might be nice if the path were more general path name like C:\OpenSSL\ssl\openssl.cnf.
