### PR TITLE
Update ruby19 :version in config/ruby_installer.rb

### DIFF
--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -54,7 +54,7 @@ module RubyInstaller
     end
 
     Ruby19 = OpenStruct.new(
-      :version => "1.9.3-p448",
+      :version => "1.9.3-p484",
       :short_version => 'ruby19',
       :url => "http://cache.ruby-lang.org/pub/ruby/1.9",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_3',


### PR DESCRIPTION
In the previous update to the ruby_installer.rb in config, only the files array was updated to 1.9.3-p484, the :version was not updated. This commit updates the :version to match the expected patchlevel of the tarball source.
