### PR TITLE
Also apply patches for rubygems

### DIFF
--- a/recipes/tools/rubygems.rake
+++ b/recipes/tools/rubygems.rake
@@ -58,11 +58,13 @@ namespace(:tools) do
     ENV['CHECKOUT'] ? task(:extract => :checkout) : task(:extract => :download)
 
     task :install18 => [package.target, RubyInstaller::Ruby18.install_target] do
+      do_patches RubyInstaller::RubyGems
       do_install RubyInstaller::RubyGems, RubyInstaller::Ruby18
       copy_devkit_hook RubyInstaller::RubyGems, RubyInstaller::Ruby18
     end
 
     task :install19 => [package.target, RubyInstaller::Ruby19.install_target] do
+      do_patches RubyInstaller::RubyGems
       do_install RubyInstaller::RubyGems, RubyInstaller::Ruby19
       copy_devkit_hook RubyInstaller::RubyGems, RubyInstaller::Ruby19
     end
@@ -112,6 +114,13 @@ TEXT
           end
           File.open(script, 'w') { |f| f.write(contents) }
         end
+      end
+    end
+
+    def do_patches(package)
+      patches = Dir.glob("#{package.patches}/*.patch").sort
+      patches.each do |patch|
+        sh "git apply --directory #{package.target} #{patch}"
       end
     end
 


### PR DESCRIPTION
Previously adding patches for rubygems would not actually patch the rubygems
source before installing because the patch action had not been defined for
rubygems. This means that if a ruby was being built with rubygems that needed
patching, for a CVE or a bugfix, the patch would not be applied. This commit
adds a do_patches method, copied verbatim out of the ruby18/ruby19 rake tasks,
and the do_patches method is then invoked during the rubygems install. With
this commit, patches can be added for rubygems in the same way they are added
for ruby18 and ruby19.
