### PR TITLE
Delete tcl, tk dependency with NOTK=1 on Ruby20, 21

### DIFF
--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -196,6 +196,8 @@ module RubyInstaller
       [:tcl, :tk].each do |pkg|
         Ruby18.dependencies.delete(pkg)
         Ruby19.dependencies.delete(pkg)
+        Ruby20.dependencies.delete(pkg)
+        Ruby21.dependencies.delete(pkg)
       end
     end
 


### PR DESCRIPTION
ext/tk will not be built with NOTK=1. It is same as Ruby 18, 19.
