### PR TITLE
Make dk.rb support x64 ruby

### DIFF
--- a/resources/devkit/dk.rb.erb
+++ b/resources/devkit/dk.rb.erb
@@ -11,7 +11,8 @@ module DevKitInstaller
   DEVKIT_END = ':DK-END:'
 
   REG_KEYS = [
-    'Software\RubyInstaller\MRI'
+    'Software\RubyInstaller\MRI',
+    'SOFTWARE\Wow6432Node\RubyInstaller\MRI'
   ]
 
   CONFIG_FILE = 'config.yml'


### PR DESCRIPTION
I was having difficulty installing ruby & devkit via chocolatey. `ruby dk.rb init` was not finding the installed ruby (which for reference gets put into `c:/tools/ruby200`).

I was attempting this on Windows 2012 R2 x64, in AWS, via eu-west-1 ami-6abd621d.
* Chocolatey 0.9.8.27
* ruby via [chocolatey package 2.0.0.48100](http://chocolatey.org/packages/ruby/2.0.0.48100) (latest at time)
* ruby devkit via [chocolatey package 4.7.2.2013022401](http://chocolatey.org/packages/ruby2.devkit/4.7.2.2013022401) (latest at time)

I discovered that the install-location is stored in a slightly different search path on the machine that I installed to. I assume this is an x86/x64 difference, but don't really know enough about that area to be certain.

My test consisted of
* `choco install ruby`
* `choco install ruby2.devkit`
* edit dk.rb as in the diff
* run `ruby dk.rb init` from `c:/devkit2` (which is where chocolatey puts it)
* observe that it has generated `config.yml` with the install-location to my ruby (`c:/tools/ruby200`, where chocolatey puts that)
* run `ruby dk.rb install` and then the standard test using json gem; success