### PR TITLE
Disregard mkrf_conf.rb as a requirement for DevKit

### DIFF
--- a/resources/rubygems/operating_system.rb
+++ b/resources/rubygems/operating_system.rb
@@ -1,6 +1,6 @@
 # :DK-BEG: missing DevKit/build tool convenience notice
 Gem.pre_install do |gem_installer|
-  unless gem_installer.spec.extensions.empty?
+  unless gem_installer.spec.extensions.reject { |extension| /mkrf_conf/ === extension }.empty?
     begin
       load 'devkit'
     rescue LoadError


### PR DESCRIPTION
It has become a common trick to use an extension configure script named `mkrf_conf.rb` to conditionally install extra dependencies via Gem::DependencyInstaller when installing a gem.

cf. http://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_install_different_versions_of_gems_depending_on_which_version_of_ruby_the_installee_is_using

A `mkrf_conf.rb` script is expected to generate a `Rakefile` which is later run by a standard tool rake(1), and that doesn't necessarily require build tools like make(1), C compiler, etc.

With this change, a gem could even make a dependency on a native gem optional using a `mkrf_conf.rb` so users on Windows without DevKit could run it.