### PR TITLE
Bump to msys 1.0.18 to get new shellshock-proof bash.

### DIFF
--- a/config/devkit.rb
+++ b/config/devkit.rb
@@ -45,7 +45,7 @@ module DevKitInstaller
         'zlib-1.2.3-2-msys-1.0.13-dll.tar.lzma',
         'libgdbm-1.8.3-3-msys-1.0.13-dll-3.tar.lzma',
         'libcrypt-1.1_1-3-msys-1.0.13-dll-0.tar.lzma',
-        'bash-3.1.17-4-msys-1.0.16-bin.tar.lzma',
+        'bash-3.1.23-1-msys-1.0.18-bin.tar.lzma',
         'mksh-40.0.0c-1-msys-1.0.17-bin.tar.lzma',
         'termcap-0.20050421_1-2-msys-1.0.13-bin.tar.lzma',
         'libregex-1.20090805-2-msys-1.0.13-dll-1.tar.lzma',


### PR DESCRIPTION
For #238