### PR TITLE
generate chm file include private methods

### DIFF
--- a/config/docs.rb
+++ b/config/docs.rb
@@ -39,7 +39,7 @@ module RubyInstaller
 
     package.docs.each do |doc|
       # Build options
-      opts = []
+      opts = ['--visibility=private']
       opts.concat ['-x', doc.exclude] if doc.exclude
       doc.opts = opts unless opts.empty?
 


### PR DESCRIPTION
from https://github.com/rdoc/rdoc/pull/276

rdoc default generate html not include private methods document.