### PR TITLE
Enable side-by-side private assembly

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,4 @@
-=== (In Git)
+=== 2016-12-6
 
 * Enhancements
   * Upgraded Ruby 2.3 to 2.3.3

--- a/History.txt
+++ b/History.txt
@@ -8,6 +8,9 @@
   * Upgraded LibYAML to 0.1.7
   * Upgraded tcl & tk to 8.5.19
 
+* Internal
+  * Retry timeouts with SourceForge
+
 === 2016-7-17
 
 * Enhancements

--- a/History.txt
+++ b/History.txt
@@ -3,6 +3,10 @@
 * Enhancements
   * Upgraded Ruby 2.3 to 2.3.3
   * Upgraded Ruby 2.2 to 2.2.6
+  * Upgraded OpenSSL to 1.0.2j
+  * Upgraded libffi to 3.2.1
+  * Upgraded LibYAML to 0.1.7
+  * Upgraded tcl & tk to 8.5.19
 
 === 2016-7-17
 

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+=== (In Git)
+
+* Enhancements
+  * Upgraded Ruby 2.3 to 2.3.3
+  * Upgraded Ruby 2.2 to 2.2.6
+
 === 2016-7-17
 
 * Enhancements

--- a/config/dependencies.rb
+++ b/config/dependencies.rb
@@ -17,40 +17,40 @@ module RubyInstaller
 
   KNAPSACK_PACKAGES['openssl'] = OpenStruct.new(
     :human_name => "OpenSSL",
-    :version => '1.0.1l',
+    :version => '1.0.2j',
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => 'sandbox/openssl',
     :files => [
-      'openssl-1.0.1l-x86-windows.tar.lzma'
+      'openssl-1.0.2j-x86-windows.tar.lzma'
     ],
     :x64_files => [
-      'openssl-1.0.1l-x64-windows.tar.lzma'
+      'openssl-1.0.2j-x64-windows.tar.lzma'
     ]
   )
 
   KNAPSACK_PACKAGES['ffi'] = OpenStruct.new(
     :human_name => "libffi",
-    :version => '3.0.11',
+    :version => '3.2.1',
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => 'sandbox/libffi',
     :files => [
-      'libffi-3.0.11-x86-windows.tar.lzma'
+      'libffi-3.2.1-x86-windows.tar.lzma'
     ],
     :x64_files => [
-      'libffi-3.0.11-x64-windows.tar.lzma'
+      'libffi-3.2.1-x64-windows.tar.lzma'
     ]
   )
 
   KNAPSACK_PACKAGES['yaml'] = OpenStruct.new(
     :human_name => "LibYAML",
-    :version => '0.1.6',
+    :version => '0.1.7',
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => 'sandbox/libyaml',
     :files => [
-      'libyaml-0.1.6-x86-windows.tar.lzma'
+      'libyaml-0.1.7-x86-windows.tar.lzma'
     ],
     :x64_files => [
-      'libyaml-0.1.6-x64-windows.tar.lzma'
+      'libyaml-0.1.7-x64-windows.tar.lzma'
     ]
   )
 
@@ -95,28 +95,28 @@ module RubyInstaller
 
   KNAPSACK_PACKAGES["tcl"] = OpenStruct.new(
     :human_name => "Tcl",
-    :version => "8.5.12",
+    :version => "8.5.19",
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => "sandbox/tcl",
     :files => [
-      "tcl-8.5.12-x86-windows.tar.lzma"
+      "tcl-8.5.19-x86-windows.tar.lzma"
     ],
     :x64_files => [
-      "tcl-8.5.12-x64-windows.tar.lzma"
+      "tcl-8.5.19-x64-windows.tar.lzma"
     ]
   )
 
   KNAPSACK_PACKAGES["tk"] = OpenStruct.new(
     :human_name => "Tk",
-    :version => "8.5.12",
+    :version => "8.5.19",
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => "sandbox/tk",
     :patches => "resources/patches/tk",
     :files => [
-      "tk-8.5.12-x86-windows.tar.lzma"
+      "tk-8.5.19-x86-windows.tar.lzma"
     ],
     :x64_files => [
-      "tk-8.5.12-x64-windows.tar.lzma"
+      "tk-8.5.19-x64-windows.tar.lzma"
     ],
     :dependencies => [
       :tcl

--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -151,7 +151,7 @@ module RubyInstaller
 
     Ruby22 = OpenStruct.new(
       :number  => "22",
-      :version => "2.2.5",
+      :version => "2.2.6",
       :short_version => 'ruby22',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.2/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_2',
@@ -168,7 +168,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.2.5.tar.bz2"
+        "ruby-2.2.6.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk
@@ -180,7 +180,7 @@ module RubyInstaller
 
     Ruby23 = OpenStruct.new(
       :number  => "23",
-      :version => "2.3.1",
+      :version => "2.3.3",
       :short_version => 'ruby23',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.3/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_3',
@@ -197,7 +197,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.3.1.tar.bz2"
+        "ruby-2.3.3.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk

--- a/rake/contrib/uri_ext.rb
+++ b/rake/contrib/uri_ext.rb
@@ -274,6 +274,9 @@ module URI
           end
         end
       end
+    rescue Errno::ETIMEDOUT
+      puts "Download of #{self} timed out. Retrying."
+      retry
     end
 
   private

--- a/resources/installer/rubyinstaller.iss
+++ b/resources/installer/rubyinstaller.iss
@@ -152,7 +152,7 @@ TheBookofRubyTitle=The Book of Ruby
 
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
-Source: {#RubyPath}\*; DestDir: {app}; Excludes: "\bin\tcl*.dll,\bin\tk*.dll,\lib\tcltk,\lib\ruby\{#RubyLibVersion}\tk*.rb,\lib\ruby\{#RubyLibVersion}\tcl*.rb,\lib\ruby\{#RubyLibVersion}\*-tk.rb,\lib\ruby\{#RubyLibVersion}\tk,\lib\ruby\{#RubyLibVersion}\tkextlib,\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}\tcl*.so,\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}\tk*.so"; Flags: recursesubdirs createallsubdirs
+Source: {#RubyPath}\*; DestDir: {app}; Excludes: "\bin\RubyInstaller.MRI.RubyAssembly\tcl*.dll,\bin\RubyInstaller.MRI.RubyAssembly\tk*.dll,\lib\tcltk,\lib\ruby\{#RubyLibVersion}\tk*.rb,\lib\ruby\{#RubyLibVersion}\tcl*.rb,\lib\ruby\{#RubyLibVersion}\*-tk.rb,\lib\ruby\{#RubyLibVersion}\tk,\lib\ruby\{#RubyLibVersion}\tkextlib,\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}\tcl*.so,\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}\tk*.so"; Flags: recursesubdirs createallsubdirs
 Source: setrbvars.bat; DestDir: {app}\bin
 
 [Registry]

--- a/resources/installer/tcltk.iss
+++ b/resources/installer/tcltk.iss
@@ -11,6 +11,6 @@ Source: {#RubyPath}\lib\ruby\{#RubyLibVersion}\tk\*; DestDir: {app}\lib\ruby\{#R
 Source: {#RubyPath}\lib\ruby\{#RubyLibVersion}\tkextlib\*; DestDir: {app}\lib\ruby\{#RubyLibVersion}\tkextlib; Flags: recursesubdirs createallsubdirs; Check: IsTclTk
 Source: {#RubyPath}\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}\tcl*.so; DestDir: {app}\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}; Check: IsTclTk
 Source: {#RubyPath}\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}\tk*.so; DestDir: {app}\lib\ruby\{#RubyLibVersion}\{#RubyBuildPlatform}; Check: IsTclTk
-Source: {#RubyPath}\bin\tcl*.dll; DestDir: {app}\bin; Check: IsTclTk
-Source: {#RubyPath}\bin\tk*.dll; DestDir: {app}\bin; Check: IsTclTk
+Source: {#RubyPath}\bin\RubyInstaller.MRI.RubyAssembly\tcl*.dll; DestDir: {app}\bin\RubyInstaller.MRI.RubyAssembly; Check: IsTclTk
+Source: {#RubyPath}\bin\RubyInstaller.MRI.RubyAssembly\tk*.dll; DestDir: {app}\bin\RubyInstaller.MRI.RubyAssembly; Check: IsTclTk
 Source: {#RubyPath}\lib\tcltk\*; DestDir: {app}\lib\tcltk; Flags: recursesubdirs createallsubdirs; Check: IsTclTk

--- a/resources/patches/ruby21/0001-Enable-side-by-side-assembly.patch
+++ b/resources/patches/ruby21/0001-Enable-side-by-side-assembly.patch
@@ -1,5 +1,5 @@
 diff --git a/win32/resource.rb b/win32/resource.rb
-index 786edb0..9236cad 100755
+index 786edb0..0970e15 100755
 --- a/win32/resource.rb
 +++ b/win32/resource.rb
 @@ -52,6 +52,7 @@ end
@@ -21,7 +21,7 @@ index 786edb0..9236cad 100755
  #{icon || ''}
  VS_VERSION_INFO VERSIONINFO
   FILEVERSION    #{nversion}
-@@ -95,3 +98,60 @@ EOF
+@@ -95,3 +98,45 @@ EOF
    }
  end
  
@@ -35,21 +35,6 @@ index 786edb0..9236cad 100755
 +
 +    f.print <<EOF_MANI_BIN
 +<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-+
-+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-+      <application>
-+        <!-- Windows Vista -->
-+          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-+        <!-- Windows 7 -->
-+          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-+        <!-- Windows 8 -->
-+          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-+        <!-- Windows 8.1 -->
-+          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-+        <!-- Windows 10 -->
-+          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-+      </application>
-+  </compatibility>
 +
 +  <assemblyIdentity type="win32"
 +                    name="RubyInstaller.MRI.Ruby"

--- a/resources/patches/ruby21/0001-Enable-side-by-side-assembly.patch
+++ b/resources/patches/ruby21/0001-Enable-side-by-side-assembly.patch
@@ -1,0 +1,84 @@
+diff --git a/win32/resource.rb b/win32/resource.rb
+index 786edb0..9236cad 100755
+--- a/win32/resource.rb
++++ b/win32/resource.rb
+@@ -52,6 +52,7 @@ end
+   [$rubyw_name,  CONFIG["EXEEXT"], 'VFT_APP', 'GUI', rubyw_icon || ruby_icon],
+   [$so_name,     '.dll',           'VFT_DLL', 'DLL', dll_icons.join],
+ ].each do |base, ext, type, desc, icon|
++  manifest = (type=='VFT_APP') ? "1" : "2"
+   open(base + '.rc', "w") { |f|
+     f.binmode if /mingw/ =~ RUBY_PLATFORM
+ 
+@@ -59,8 +60,10 @@ end
+ #ifndef __BORLANDC__
+ #include <windows.h>
+ #include <winver.h>
++#include <winuser.h>
+ #endif
+ 
++#{manifest} RT_MANIFEST "ruby.bin.manifest"
+ #{icon || ''}
+ VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    #{nversion}
+@@ -95,3 +98,60 @@ EOF
+   }
+ end
+ 
++manifest_version = RUBY_VERSION + ".0"
++manifest_arch = (CONFIG["target_cpu"] == "x64") ? 'amd64' :
++  (CONFIG["target_cpu"] =~ /i[3456]86/) ? 'x86' :
++  'error'
++
++open('ruby.bin.manifest', "w") { |f|
++    f.binmode if /mingw/ =~ RUBY_PLATFORM
++
++    f.print <<EOF_MANI_BIN
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++
++  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
++      <application>
++        <!-- Windows Vista -->
++          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
++        <!-- Windows 7 -->
++          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
++        <!-- Windows 8 -->
++          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
++        <!-- Windows 8.1 -->
++          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
++        <!-- Windows 10 -->
++          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
++      </application>
++  </compatibility>
++
++  <assemblyIdentity type="win32"
++                    name="RubyInstaller.MRI.Ruby"
++                    version="#{manifest_version}"
++                    processorArchitecture="#{manifest_arch}"
++  />
++
++  <dependency>
++    <dependentAssembly>
++      <assemblyIdentity type="win32"
++                        name="RubyInstaller.MRI.RubyAssembly"
++                        version="#{manifest_version}"
++                        language="*"
++                        processorArchitecture="#{manifest_arch}" />
++    </dependentAssembly>
++  </dependency>
++</assembly>
++EOF_MANI_BIN
++}
++
++open('RubyInstaller.MRI.RubyAssembly.manifest', "w") { |f|
++    f.binmode if /mingw/ =~ RUBY_PLATFORM
++
++    f.print <<EOF_MANI_ASSY
++<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++    <assemblyIdentity type="win32" name="RubyInstaller.MRI.RubyAssembly" version="#{manifest_version}" processorArchitecture="#{manifest_arch}" />
++
++<!-- PLACE_HOLDER -->
++</assembly>
++EOF_MANI_ASSY
++}

--- a/resources/patches/ruby22/0001-Enable-side-by-side-assembly.patch
+++ b/resources/patches/ruby22/0001-Enable-side-by-side-assembly.patch
@@ -1,5 +1,5 @@
 diff --git a/win32/resource.rb b/win32/resource.rb
-index 786edb0..9236cad 100755
+index 786edb0..0970e15 100755
 --- a/win32/resource.rb
 +++ b/win32/resource.rb
 @@ -52,6 +52,7 @@ end
@@ -21,7 +21,7 @@ index 786edb0..9236cad 100755
  #{icon || ''}
  VS_VERSION_INFO VERSIONINFO
   FILEVERSION    #{nversion}
-@@ -95,3 +98,60 @@ EOF
+@@ -95,3 +98,45 @@ EOF
    }
  end
  
@@ -35,21 +35,6 @@ index 786edb0..9236cad 100755
 +
 +    f.print <<EOF_MANI_BIN
 +<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-+
-+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-+      <application>
-+        <!-- Windows Vista -->
-+          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-+        <!-- Windows 7 -->
-+          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-+        <!-- Windows 8 -->
-+          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-+        <!-- Windows 8.1 -->
-+          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-+        <!-- Windows 10 -->
-+          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-+      </application>
-+  </compatibility>
 +
 +  <assemblyIdentity type="win32"
 +                    name="RubyInstaller.MRI.Ruby"

--- a/resources/patches/ruby22/0001-Enable-side-by-side-assembly.patch
+++ b/resources/patches/ruby22/0001-Enable-side-by-side-assembly.patch
@@ -1,0 +1,84 @@
+diff --git a/win32/resource.rb b/win32/resource.rb
+index 786edb0..9236cad 100755
+--- a/win32/resource.rb
++++ b/win32/resource.rb
+@@ -52,6 +52,7 @@ end
+   [$rubyw_name,  CONFIG["EXEEXT"], 'VFT_APP', 'GUI', rubyw_icon || ruby_icon],
+   [$so_name,     '.dll',           'VFT_DLL', 'DLL', dll_icons.join],
+ ].each do |base, ext, type, desc, icon|
++  manifest = (type=='VFT_APP') ? "1" : "2"
+   open(base + '.rc', "w") { |f|
+     f.binmode if /mingw/ =~ RUBY_PLATFORM
+ 
+@@ -59,8 +60,10 @@ end
+ #ifndef __BORLANDC__
+ #include <windows.h>
+ #include <winver.h>
++#include <winuser.h>
+ #endif
+ 
++#{manifest} RT_MANIFEST "ruby.bin.manifest"
+ #{icon || ''}
+ VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    #{nversion}
+@@ -95,3 +98,60 @@ EOF
+   }
+ end
+ 
++manifest_version = RUBY_VERSION + ".0"
++manifest_arch = (CONFIG["target_cpu"] == "x64") ? 'amd64' :
++  (CONFIG["target_cpu"] =~ /i[3456]86/) ? 'x86' :
++  'error'
++
++open('ruby.bin.manifest', "w") { |f|
++    f.binmode if /mingw/ =~ RUBY_PLATFORM
++
++    f.print <<EOF_MANI_BIN
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++
++  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
++      <application>
++        <!-- Windows Vista -->
++          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
++        <!-- Windows 7 -->
++          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
++        <!-- Windows 8 -->
++          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
++        <!-- Windows 8.1 -->
++          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
++        <!-- Windows 10 -->
++          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
++      </application>
++  </compatibility>
++
++  <assemblyIdentity type="win32"
++                    name="RubyInstaller.MRI.Ruby"
++                    version="#{manifest_version}"
++                    processorArchitecture="#{manifest_arch}"
++  />
++
++  <dependency>
++    <dependentAssembly>
++      <assemblyIdentity type="win32"
++                        name="RubyInstaller.MRI.RubyAssembly"
++                        version="#{manifest_version}"
++                        language="*"
++                        processorArchitecture="#{manifest_arch}" />
++    </dependentAssembly>
++  </dependency>
++</assembly>
++EOF_MANI_BIN
++}
++
++open('RubyInstaller.MRI.RubyAssembly.manifest', "w") { |f|
++    f.binmode if /mingw/ =~ RUBY_PLATFORM
++
++    f.print <<EOF_MANI_ASSY
++<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++    <assemblyIdentity type="win32" name="RubyInstaller.MRI.RubyAssembly" version="#{manifest_version}" processorArchitecture="#{manifest_arch}" />
++
++<!-- PLACE_HOLDER -->
++</assembly>
++EOF_MANI_ASSY
++}

--- a/resources/patches/ruby23/0001-Enable-side-by-side-assembly.patch
+++ b/resources/patches/ruby23/0001-Enable-side-by-side-assembly.patch
@@ -1,5 +1,5 @@
 diff --git a/win32/resource.rb b/win32/resource.rb
-index 6468233..5cad6ed 100755
+index 6468233..72a352e 100755
 --- a/win32/resource.rb
 +++ b/win32/resource.rb
 @@ -52,13 +52,16 @@ def icons.find(path)
@@ -19,7 +19,7 @@ index 6468233..5cad6ed 100755
  #{icon || ''}
  VS_VERSION_INFO VERSIONINFO
   FILEVERSION    #{nversion}
-@@ -93,3 +96,60 @@ def icons.find(path)
+@@ -93,3 +96,45 @@ def icons.find(path)
    }
  end
  
@@ -33,21 +33,6 @@ index 6468233..5cad6ed 100755
 +
 +    f.print <<EOF_MANI_BIN
 +<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-+
-+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-+      <application>
-+        <!-- Windows Vista -->
-+          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-+        <!-- Windows 7 -->
-+          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-+        <!-- Windows 8 -->
-+          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-+        <!-- Windows 8.1 -->
-+          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-+        <!-- Windows 10 -->
-+          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-+      </application>
-+  </compatibility>
 +
 +  <assemblyIdentity type="win32"
 +                    name="RubyInstaller.MRI.Ruby"

--- a/resources/patches/ruby23/0001-Enable-side-by-side-assembly.patch
+++ b/resources/patches/ruby23/0001-Enable-side-by-side-assembly.patch
@@ -1,0 +1,82 @@
+diff --git a/win32/resource.rb b/win32/resource.rb
+index 6468233..5cad6ed 100755
+--- a/win32/resource.rb
++++ b/win32/resource.rb
+@@ -52,13 +52,16 @@ def icons.find(path)
+   [$rubyw_name,  CONFIG["EXEEXT"], 'VFT_APP', 'GUI', rubyw_icon || ruby_icon],
+   [$so_name,     '.dll',           'VFT_DLL', 'DLL', dll_icons.join],
+ ].each do |base, ext, type, desc, icon|
++  manifest = (type=='VFT_APP') ? "1" : "2"
+   open(base + '.rc', "w") { |f|
+     f.binmode if /mingw/ =~ RUBY_PLATFORM
+ 
+     f.print <<EOF
+ #include <windows.h>
+ #include <winver.h>
++#include <winuser.h>
+ 
++#{manifest} RT_MANIFEST "ruby.bin.manifest"
+ #{icon || ''}
+ VS_VERSION_INFO VERSIONINFO
+  FILEVERSION    #{nversion}
+@@ -93,3 +96,60 @@ def icons.find(path)
+   }
+ end
+ 
++manifest_version = RUBY_VERSION + ".0"
++manifest_arch = (CONFIG["target_cpu"] == "x64") ? 'amd64' :
++  (CONFIG["target_cpu"] =~ /i[3456]86/) ? 'x86' :
++  'error'
++
++open('ruby.bin.manifest', "w") { |f|
++    f.binmode if /mingw/ =~ RUBY_PLATFORM
++
++    f.print <<EOF_MANI_BIN
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++
++  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
++      <application>
++        <!-- Windows Vista -->
++          <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
++        <!-- Windows 7 -->
++          <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
++        <!-- Windows 8 -->
++          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
++        <!-- Windows 8.1 -->
++          <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
++        <!-- Windows 10 -->
++          <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
++      </application>
++  </compatibility>
++
++  <assemblyIdentity type="win32"
++                    name="RubyInstaller.MRI.Ruby"
++                    version="#{manifest_version}"
++                    processorArchitecture="#{manifest_arch}"
++  />
++
++  <dependency>
++    <dependentAssembly>
++      <assemblyIdentity type="win32"
++                        name="RubyInstaller.MRI.RubyAssembly"
++                        version="#{manifest_version}"
++                        language="*"
++                        processorArchitecture="#{manifest_arch}" />
++    </dependentAssembly>
++  </dependency>
++</assembly>
++EOF_MANI_BIN
++}
++
++open('RubyInstaller.MRI.RubyAssembly.manifest', "w") { |f|
++    f.binmode if /mingw/ =~ RUBY_PLATFORM
++
++    f.print <<EOF_MANI_ASSY
++<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
++<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
++    <assemblyIdentity type="win32" name="RubyInstaller.MRI.RubyAssembly" version="#{manifest_version}" processorArchitecture="#{manifest_arch}" />
++
++<!-- PLACE_HOLDER -->
++</assembly>
++EOF_MANI_ASSY
++}


### PR DESCRIPTION
This PR enables side-by-side private assembly.

I know patching the ruby source is out of the RubyInstaller's policy.
But, since this is packaging issue, I chose committing to the RubyInstaller
rather than reporting to the Ruby official repository.

With this PR, I changed the common dlls' install path to under 
the bin/RubyInstaller.MRI.RubyAssembly directory
so that the PATH setting to the ruby.exe does not affect other applications 
that use same name dlls.

Hope this makes RubyInstaller's ruby more stable and easy to update
the toolchain.

<pre>
[Done   ] ruby*, check*
[Not yet] ruby*:package:installer
</pre>
