### PR TITLE
Upgrade Ruby 2.1, 2.2 and 2.3

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,10 @@
+=== 2016-5-27
+
+* Enhancements:
+  * Upgraded Ruby 2.3 to 2.3.1
+  * Upgraded Ruby 2.2 to 2.2.5
+  * Upgraded Ruby 2.1 to 2.1.9
+
 === 2016-2-3
 
 * Enhancements:

--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -120,7 +120,7 @@ module RubyInstaller
 
     Ruby21 = OpenStruct.new(
       :number  => "21",
-      :version => "2.1.8",
+      :version => "2.1.9",
       :short_version => 'ruby21',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.1/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_1',
@@ -137,7 +137,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.1.8.tar.bz2"
+        "ruby-2.1.9.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :iconv, :openssl, :yaml, :zlib, :tcl, :tk
@@ -151,7 +151,7 @@ module RubyInstaller
 
     Ruby22 = OpenStruct.new(
       :number  => "22",
-      :version => "2.2.4",
+      :version => "2.2.5",
       :short_version => 'ruby22',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.2/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_2',
@@ -168,7 +168,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.2.4.tar.bz2"
+        "ruby-2.2.5.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk
@@ -180,7 +180,7 @@ module RubyInstaller
 
     Ruby23 = OpenStruct.new(
       :number  => "23",
-      :version => "2.3.0",
+      :version => "2.3.1",
       :short_version => 'ruby23',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.3/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_3',
@@ -197,7 +197,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.3.0.tar.bz2"
+        "ruby-2.3.1.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk


### PR DESCRIPTION
- Fixes #318 
- Inlcudes same changes as #320 

Tested locally.