### PR TITLE
Specify the 'downloads' directory

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,4 @@
-=== (In Git)
+=== 2016-12-6
 
 * Enhancements
   * Upgraded Ruby 2.3 to 2.3.3

--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,4 @@
-=== 2016-11-21
+=== (In Git)
 
 * Enhancements
   * Upgraded Ruby 2.3 to 2.3.3

--- a/History.txt
+++ b/History.txt
@@ -8,6 +8,9 @@
   * Upgraded LibYAML to 0.1.7
   * Upgraded tcl & tk to 8.5.19
 
+* Internal
+  * Retry timeouts with SourceForge
+
 === 2016-7-17
 
 * Enhancements

--- a/History.txt
+++ b/History.txt
@@ -3,6 +3,10 @@
 * Enhancements
   * Upgraded Ruby 2.3 to 2.3.3
   * Upgraded Ruby 2.2 to 2.2.6
+  * Upgraded OpenSSL to 1.0.2j
+  * Upgraded libffi to 3.2.1
+  * Upgraded LibYAML to 0.1.7
+  * Upgraded tcl & tk to 8.5.19
 
 === 2016-7-17
 

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,9 @@
+=== 2016-11-21
+
+* Enhancements
+  * Upgraded Ruby 2.3 to 2.3.3
+  * Upgraded Ruby 2.2 to 2.2.6
+
 === 2016-7-17
 
 * Enhancements

--- a/config/compilers/mingw64.rb
+++ b/config/compilers/mingw64.rb
@@ -1,5 +1,151 @@
 module DevKitInstaller
 
+  COMPILERS['mingw64-32-6.1.0-dgn'] =
+    OpenStruct.new(
+      :version => 'mingw64-32-6.1.0-dgn',
+      :programs => [ :gcc, :cpp, :'g++' ],
+      :program_prefix => nil,
+      :url_1 => 'http://downloads.sourceforge.net/mingw-w64-dgn',
+      :url_2 => 'http://downloads.sourceforge.net/mingw',
+      :url_3 => 'http://downloads.sourceforge.net/gnuwin32',
+      :target => 'sandbox/devkit/mingw',
+      :relocate => 'sandbox/devkit/mingw/mingw32',
+      :knap_path => '610-drangon',
+      :files => {
+        :url_1 => [
+          'mingw-w32-bin-i686-20160428.7z'
+        ],
+        :url_2 => [
+          'autoconf2.1-2.13-4-mingw32-bin.tar.lzma',
+          'autoconf2.5-2.68-1-mingw32-bin.tar.lzma',
+          'autoconf-10-1-mingw32-bin.tar.lzma',
+          'automake1.11-1.11.1-1-mingw32-bin.tar.lzma',
+          'automake-4-1-mingw32-bin.tar.lzma',
+          'libexpat-2.0.1-1-mingw32-dll-1.tar.gz',
+          'libtool-2.4-1-mingw32-bin.tar.lzma',
+          'bsdtar-2.8.3-1-mingw32-bin.tar.bz2',
+          'bsdcpio-2.8.3-1-mingw32-bin.tar.bz2',
+          'libarchive-2.8.3-1-mingw32-dll-2.tar.bz2',
+          'libbz2-1.0.5-2-mingw32-dll-2.tar.gz',
+          'liblzma-4.999.9beta_20100401-1-mingw32-dll-1.tar.bz2',
+          'libz-1.2.3-1-mingw32-dll-1.tar.gz'
+        ],
+        :url_3 => [
+          'which-2.20-bin.zip'
+        ],
+      }
+    )
+
+  COMPILERS['mingw64-64-6.1.0-dgn'] =
+    OpenStruct.new(
+      :version => 'mingw64-64-6.1.0-dgn',
+      :programs => [ :gcc, :cpp, :'g++' ],
+      :program_prefix => nil,
+      :url_1 => 'http://downloads.sourceforge.net/mingw-w64-dgn',
+      :url_2 => 'http://downloads.sourceforge.net/mingw',
+      :url_3 => 'http://downloads.sourceforge.net/gnuwin32',
+      :target => 'sandbox/devkit/mingw',
+      :relocate => 'sandbox/devkit/mingw/mingw64',
+      :host => 'x86_64-w64-mingw32',
+      :knap_path => '610-drangon',
+      :files => {
+        :url_1 => [
+          'mingw-w64-bin-x86_64-20160428.7z'
+        ],
+        :url_2 => [
+          'autoconf2.1-2.13-4-mingw32-bin.tar.lzma',
+          'autoconf2.5-2.68-1-mingw32-bin.tar.lzma',
+          'autoconf-10-1-mingw32-bin.tar.lzma',
+          'automake1.11-1.11.1-1-mingw32-bin.tar.lzma',
+          'automake-4-1-mingw32-bin.tar.lzma',
+          'libexpat-2.0.1-1-mingw32-dll-1.tar.gz',
+          'libtool-2.4-1-mingw32-bin.tar.lzma',
+          'bsdtar-2.8.3-1-mingw32-bin.tar.bz2',
+          'bsdcpio-2.8.3-1-mingw32-bin.tar.bz2',
+          'libarchive-2.8.3-1-mingw32-dll-2.tar.bz2',
+          'libbz2-1.0.5-2-mingw32-dll-2.tar.gz',
+          'liblzma-4.999.9beta_20100401-1-mingw32-dll-1.tar.bz2',
+          'libz-1.2.3-1-mingw32-dll-1.tar.gz'
+        ],
+        :url_3 => [
+          'which-2.20-bin.zip'
+        ],
+      }
+    )
+
+  COMPILERS['mingw64-32-5.3.0'] =
+    OpenStruct.new(
+      :version => 'mingw64-32-5.3.0',
+      :programs => [ :gcc, :cpp, :'g++' ],
+      :program_prefix => nil,
+      :url_1 => 'http://downloads.sourceforge.net/mingw-w64',
+      :url_2 => 'http://downloads.sourceforge.net/mingw',
+      :url_3 => 'http://downloads.sourceforge.net/gnuwin32',
+      :target => 'sandbox/devkit/mingw',
+      :relocate => 'sandbox/devkit/mingw/mingw32',
+      :knap_path => '530-win32-sjlj',
+      :files => {
+        :url_1 => [
+          'i686-5.3.0-release-win32-sjlj-rt_v4-rev0.7z'
+        ],
+        :url_2 => [
+          'autoconf2.1-2.13-4-mingw32-bin.tar.lzma',
+          'autoconf2.5-2.68-1-mingw32-bin.tar.lzma',
+          'autoconf-10-1-mingw32-bin.tar.lzma',
+          'automake1.11-1.11.1-1-mingw32-bin.tar.lzma',
+          'automake-4-1-mingw32-bin.tar.lzma',
+          'libexpat-2.0.1-1-mingw32-dll-1.tar.gz',
+          'libtool-2.4-1-mingw32-bin.tar.lzma',
+          'bsdtar-2.8.3-1-mingw32-bin.tar.bz2',
+          'bsdcpio-2.8.3-1-mingw32-bin.tar.bz2',
+          'libarchive-2.8.3-1-mingw32-dll-2.tar.bz2',
+          'libbz2-1.0.5-2-mingw32-dll-2.tar.gz',
+          'liblzma-4.999.9beta_20100401-1-mingw32-dll-1.tar.bz2',
+          'libz-1.2.3-1-mingw32-dll-1.tar.gz'
+        ],
+        :url_3 => [
+          'which-2.20-bin.zip'
+        ],
+      }
+    )
+
+  COMPILERS['mingw64-64-5.3.0'] =
+    OpenStruct.new(
+      :version => 'mingw64-64-5.3.0',
+      :programs => [ :gcc, :cpp, :'g++' ],
+      :program_prefix => nil,
+      :url_1 => 'http://downloads.sourceforge.net/mingw-w64',
+      :url_2 => 'http://downloads.sourceforge.net/mingw',
+      :url_3 => 'http://downloads.sourceforge.net/gnuwin32',
+      :target => 'sandbox/devkit/mingw',
+      :relocate => 'sandbox/devkit/mingw/mingw64',
+      :host => 'x86_64-w64-mingw32',
+      :knap_path => '530-win32-seh',
+      :files => {
+        :url_1 => [
+          'x86_64-5.3.0-release-win32-seh-rt_v4-rev0.7z'
+        ],
+        :url_2 => [
+          'autoconf2.1-2.13-4-mingw32-bin.tar.lzma',
+          'autoconf2.5-2.68-1-mingw32-bin.tar.lzma',
+          'autoconf-10-1-mingw32-bin.tar.lzma',
+          'automake1.11-1.11.1-1-mingw32-bin.tar.lzma',
+          'automake-4-1-mingw32-bin.tar.lzma',
+          'libexpat-2.0.1-1-mingw32-dll-1.tar.gz',
+          'libtool-2.4-1-mingw32-bin.tar.lzma',
+          'bsdtar-2.8.3-1-mingw32-bin.tar.bz2',
+          'bsdcpio-2.8.3-1-mingw32-bin.tar.bz2',
+          'libarchive-2.8.3-1-mingw32-dll-2.tar.bz2',
+          'libbz2-1.0.5-2-mingw32-dll-2.tar.gz',
+          'liblzma-4.999.9beta_20100401-1-mingw32-dll-1.tar.bz2',
+          'libz-1.2.3-1-mingw32-dll-1.tar.gz'
+        ],
+        :url_3 => [
+          'which-2.20-bin.zip'
+        ],
+      }
+    )
+
   COMPILERS['mingw64-32-4.7.2'] =
     OpenStruct.new(
       :version => 'mingw64-32-4.7.2',

--- a/config/dependencies.rb
+++ b/config/dependencies.rb
@@ -17,40 +17,40 @@ module RubyInstaller
 
   KNAPSACK_PACKAGES['openssl'] = OpenStruct.new(
     :human_name => "OpenSSL",
-    :version => '1.0.1l',
+    :version => '1.0.2j',
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => 'sandbox/openssl',
     :files => [
-      'openssl-1.0.1l-x86-windows.tar.lzma'
+      'openssl-1.0.2j-x86-windows.tar.lzma'
     ],
     :x64_files => [
-      'openssl-1.0.1l-x64-windows.tar.lzma'
+      'openssl-1.0.2j-x64-windows.tar.lzma'
     ]
   )
 
   KNAPSACK_PACKAGES['ffi'] = OpenStruct.new(
     :human_name => "libffi",
-    :version => '3.0.11',
+    :version => '3.2.1',
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => 'sandbox/libffi',
     :files => [
-      'libffi-3.0.11-x86-windows.tar.lzma'
+      'libffi-3.2.1-x86-windows.tar.lzma'
     ],
     :x64_files => [
-      'libffi-3.0.11-x64-windows.tar.lzma'
+      'libffi-3.2.1-x64-windows.tar.lzma'
     ]
   )
 
   KNAPSACK_PACKAGES['yaml'] = OpenStruct.new(
     :human_name => "LibYAML",
-    :version => '0.1.6',
+    :version => '0.1.7',
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => 'sandbox/libyaml',
     :files => [
-      'libyaml-0.1.6-x86-windows.tar.lzma'
+      'libyaml-0.1.7-x86-windows.tar.lzma'
     ],
     :x64_files => [
-      'libyaml-0.1.6-x64-windows.tar.lzma'
+      'libyaml-0.1.7-x64-windows.tar.lzma'
     ]
   )
 
@@ -95,28 +95,28 @@ module RubyInstaller
 
   KNAPSACK_PACKAGES["tcl"] = OpenStruct.new(
     :human_name => "Tcl",
-    :version => "8.5.12",
+    :version => "8.5.19",
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => "sandbox/tcl",
     :files => [
-      "tcl-8.5.12-x86-windows.tar.lzma"
+      "tcl-8.5.19-x86-windows.tar.lzma"
     ],
     :x64_files => [
-      "tcl-8.5.12-x64-windows.tar.lzma"
+      "tcl-8.5.19-x64-windows.tar.lzma"
     ]
   )
 
   KNAPSACK_PACKAGES["tk"] = OpenStruct.new(
     :human_name => "Tk",
-    :version => "8.5.12",
+    :version => "8.5.19",
     :url => "http://dl.bintray.com/oneclick/OpenKnapsack",
     :target => "sandbox/tk",
     :patches => "resources/patches/tk",
     :files => [
-      "tk-8.5.12-x86-windows.tar.lzma"
+      "tk-8.5.19-x86-windows.tar.lzma"
     ],
     :x64_files => [
-      "tk-8.5.12-x64-windows.tar.lzma"
+      "tk-8.5.19-x64-windows.tar.lzma"
     ],
     :dependencies => [
       :tcl

--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -5,6 +5,9 @@ module RubyInstaller
     # Root folder
     ROOT = File.expand_path(File.join(File.dirname(__FILE__), ".."))
 
+    # Downloads folder
+    DOWNLOADS = ENV['DOWNLOADS'] || "downloads"
+
     # Console based utilities
     SEVEN_ZIP = File.expand_path(File.join(ROOT, 'sandbox', 'extract_utils', '7za.exe'))
     BSD_TAR = File.expand_path(File.join(ROOT, 'sandbox', 'extract_utils', 'basic-bsdtar.exe'))

--- a/config/ruby_installer.rb
+++ b/config/ruby_installer.rb
@@ -151,7 +151,7 @@ module RubyInstaller
 
     Ruby22 = OpenStruct.new(
       :number  => "22",
-      :version => "2.2.5",
+      :version => "2.2.6",
       :short_version => 'ruby22',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.2/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_2',
@@ -168,7 +168,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.2.5.tar.bz2"
+        "ruby-2.2.6.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk
@@ -180,7 +180,7 @@ module RubyInstaller
 
     Ruby23 = OpenStruct.new(
       :number  => "23",
-      :version => "2.3.1",
+      :version => "2.3.3",
       :short_version => 'ruby23',
       :url => "http://cache.ruby-lang.org/pub/ruby/2.3/",
       :checkout => 'http://svn.ruby-lang.org/repos/ruby/branches/ruby_2_3',
@@ -197,7 +197,7 @@ module RubyInstaller
         "CPPFLAGS='-DFD_SETSIZE=2048'"
       ],
       :files => [
-        "ruby-2.3.1.tar.bz2"
+        "ruby-2.3.3.tar.bz2"
       ],
       :dependencies => [
         :ffi, :gdbm, :openssl, :yaml, :zlib, :tcl, :tk

--- a/rake/contrib/uri_ext.rb
+++ b/rake/contrib/uri_ext.rb
@@ -274,6 +274,9 @@ module URI
           end
         end
       end
+    rescue Errno::ETIMEDOUT
+      puts "Download of #{self} timed out. Retrying."
+      retry
     end
 
   private

--- a/recipes/certificate.rake
+++ b/recipes/certificate.rake
@@ -2,7 +2,7 @@ namespace :certificate do
   cert = RubyInstaller::Certificate
 
   source = "#{cert.url}/#{cert.file}"
-  target = "downloads/#{cert.file}"
+  target = "#{RubyInstaller::DOWNLOADS}/#{cert.file}"
 
   download target => source
   task :download => target

--- a/recipes/common.rake
+++ b/recipes/common.rake
@@ -3,8 +3,8 @@ require 'rake/clean'
 
 # default cleanup
 CLOBBER.include("sandbox")
-CLOBBER.include("downloads")
+CLOBBER.include(RubyInstaller::DOWNLOADS)
 
 # define common tasks
-directory "downloads"
+directory (RubyInstaller::DOWNLOADS)
 directory "sandbox"

--- a/recipes/dependencies/knapsack.rake
+++ b/recipes/dependencies/knapsack.rake
@@ -16,15 +16,15 @@ dependencies.each do |dependency_key, dependency|
         if compiler.knap_path
           files_url = "#{dependency.url}/#{compiler.knap_path}/x64"
         else
-        files_url = "#{dependency.url}/x64"
+          files_url = "#{dependency.url}/x64"
         end
       else
         files = dependency.files
         if compiler.knap_path
           files_url = "#{dependency.url}/#{compiler.knap_path}/x86"
         else
-        files_url = "#{dependency.url}/x86"
-      end
+          files_url = "#{dependency.url}/x86"
+        end
       end
 
       download_path = RubyInstaller::DOWNLOADS

--- a/recipes/dependencies/knapsack.rake
+++ b/recipes/dependencies/knapsack.rake
@@ -13,19 +13,33 @@ dependencies.each do |dependency_key, dependency|
 
       if compiler.host =~ /x86_64/
         files = dependency.x64_files
+        if compiler.knap_path
+          files_url = "#{dependency.url}/#{compiler.knap_path}/x64"
+        else
         files_url = "#{dependency.url}/x64"
+        end
       else
         files = dependency.files
+        if compiler.knap_path
+          files_url = "#{dependency.url}/#{compiler.knap_path}/x86"
+        else
         files_url = "#{dependency.url}/x86"
+      end
+      end
+
+      download_path = RubyInstaller::DOWNLOADS
+      if compiler.knap_path
+        download_path = "#{download_path}/#{compiler.knap_path}"
       end
 
       files.each do |f|
         file_source = "#{files_url}/#{f}"
-        file_target = "downloads/#{f}"
+        file_target = "#{download_path}/#{f}"
         download file_target => file_source
 
         # depend on downloads directory
-        file file_target => "downloads"
+        file file_target => "#{download_path}"
+        directory "#{download_path}"
 
         # download task need these files as pre-requisites
         dt.enhance [file_target]
@@ -35,7 +49,7 @@ dependencies.each do |dependency_key, dependency|
       # Prepare the :sandbox, it requires the :download task
       et = checkpoint(dependency_key, :extract) do
         dt.prerequisites.each { |f|
-          extract(File.join(RubyInstaller::ROOT, f), dependency.target)
+          extract(f, dependency.target)
         }
       end
       task :extract => [:extract_utils, :download, dependency.target, et]

--- a/recipes/dependencies/rbreadline.rake
+++ b/recipes/dependencies/rbreadline.rake
@@ -10,11 +10,11 @@ namespace(:dependencies) do
     # Put files for the :download task
     package.files.each do |f|
       file_source = "#{package.url}/#{f}"
-      file_target = "downloads/#{f}"
+      file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
       download file_target => file_source
 
       # depend on downloads directory
-      file file_target => "downloads"
+      file file_target => RubyInstaller::DOWNLOADS
 
       # download task need these files as pre-requisites
       task :download => file_target
@@ -26,7 +26,7 @@ namespace(:dependencies) do
       files = Rake::Task['dependencies:rbreadline:download'].prerequisites
 
       files.each { |f|
-        extract(File.join(RubyInstaller::ROOT, f), package.target)
+        extract(f, package.target)
       }
     end
 

--- a/recipes/devkit/mingw.rake
+++ b/recipes/devkit/mingw.rake
@@ -14,11 +14,11 @@ namespace(:devkit) do
       v.each do |f|
         #TODO handle exception when no corresponding URL defined on package
         file_source = "#{package.send(k)}/#{f}"
-        file_target = "downloads/#{f}"
+        file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
         download file_target => file_source
 
         # depend on downloads directory
-        file file_target => "downloads"
+        file file_target => RubyInstaller::DOWNLOADS
 
         # download task needs the packages files as pre-requisites
         dt.enhance [file_target]
@@ -31,7 +31,7 @@ namespace(:devkit) do
     et = checkpoint(:mingw, :extract) do
       dt.prerequisites.each do |f|
         fail "[FAIL] corrupt '#{f}' archive" unless seven_zip_valid?(f)
-        extract(File.join(RubyInstaller::ROOT, f), package.target)
+        extract(f, package.target)
       end
     end
     task :extract => [:extract_utils, :download, package.target, et]

--- a/recipes/devkit/msys.rake
+++ b/recipes/devkit/msys.rake
@@ -12,11 +12,11 @@ namespace(:devkit) do
       v.each do |f|
         #TODO handle exception when no corresponding URL defined on package
         file_source = "#{package.send(k)}/#{f}"
-        file_target = "downloads/#{f}"
+        file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
         download file_target => file_source
 
         # depend on downloads directory
-        file file_target => "downloads"
+        file file_target => RubyInstaller::DOWNLOADS
 
         # download task needs the packages files as pre-requisites
         dt.enhance [file_target]
@@ -29,7 +29,7 @@ namespace(:devkit) do
     et = checkpoint(:msys, :extract) do
       dt.prerequisites.each do |f|
         fail "[FAIL] corrupt '#{f}' archive" unless seven_zip_valid?(f)
-        extract(File.join(RubyInstaller::ROOT, f), package.target)
+        extract(f, package.target)
       end
     end
     task :extract => [:extract_utils, :download, package.target, et]

--- a/recipes/extract_utils/extract_utils.rake
+++ b/recipes/extract_utils/extract_utils.rake
@@ -10,11 +10,11 @@ namespace(:extract_utils) do
     v.each do |f|
       #TODO handle exception when no corresponding URL defined on package
       file_source = "#{package.send(k)}/#{f}"
-      file_target = "downloads/#{f}"
+      file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
       download file_target => file_source
 
       # depend on downloads directory
-      file file_target => "downloads"
+      file file_target => RubyInstaller::DOWNLOADS
 
       # download task need these files as pre-requisites
       task :download => file_target
@@ -35,13 +35,13 @@ namespace(:extract_utils) do
     fail 'Only one .msi allowed for RubyInstaller::ExtractUtils.files' if msis.length != 1
 
     zips.each do |f|
-      filename = "downloads/#{f}"
+      filename = "#{RubyInstaller::DOWNLOADS}/#{f}"
       Zip.fake_unzip(filename, /\.exe|\.dll$/, package.target)
     end
 
     # assume 7za.exe can extract individual files from MSI's
     unless File.exist?("#{package.target}/7z.sfx")
-      msi = "downloads/#{msis.first}"
+      msi = "#{RubyInstaller::DOWNLOADS}/#{msis.first}"
       seven_zip_get(msi, '_7z.sfx', package.target)
       File.rename("#{package.target}/_7z.sfx", "#{package.target}/7z.sfx")
     end

--- a/recipes/interpreter/rubies.rake
+++ b/recipes/interpreter/rubies.rake
@@ -18,17 +18,17 @@ interpreters.each do |package|
       # Put files for the :download task
       package.files.each do |f|
         file_source = "#{package.url}/#{f}"
-        file_target = "downloads/#{f}"
+        file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
         download file_target => file_source
 
         # depend on downloads directory
-        file file_target => "downloads"
+        file file_target => RubyInstaller::DOWNLOADS
 
         # download task need these files as pre-requisites
         task :download => file_target
       end
 
-      task :checkout => "downloads" do
+      task :checkout => RubyInstaller::DOWNLOADS do
         cd RubyInstaller::ROOT do
           # If is there already a checkout, update instead of checkout"
           if File.exist?(File.join(RubyInstaller::ROOT, package.checkout_target, '.svn'))
@@ -67,7 +67,7 @@ interpreters.each do |package|
           mkdir_p package.target
 
           files.each { |f|
-            extract(File.join(RubyInstaller::ROOT, f), package.target)
+            extract(f, package.target)
           }
         end
       end

--- a/recipes/tools/book.rake
+++ b/recipes/tools/book.rake
@@ -10,11 +10,11 @@ namespace(:book) do
   dt = checkpoint(:book, :download)
   package.files.each do |f|
     file_source = "#{package.url}/#{f}"
-    file_target = "downloads/#{f}"
+    file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
     download file_target => file_source
 
     # depend on downloads directory
-    file file_target => "downloads"
+    file file_target => RubyInstaller::DOWNLOADS
 
     # download task need these files as pre-requisites
     dt.enhance [file_target]
@@ -24,7 +24,7 @@ namespace(:book) do
   # Prepare the :sandbox, it requires the :download task
   et = checkpoint(:book, :extract) do
     dt.prerequisites.each { |f|
-      extract(File.join(RubyInstaller::ROOT, f), package.target)
+      extract(f, package.target)
     }
   end
   task :extract => [:extract_utils, :download, package.target, et]

--- a/recipes/tools/rubygems.rake
+++ b/recipes/tools/rubygems.rake
@@ -10,17 +10,17 @@ namespace(:tools) do
     # Put files for the :download task
     package.files.each do |f|
       file_source = "#{package.url}/#{f}"
-      file_target = "downloads/#{f}"
+      file_target = "#{RubyInstaller::DOWNLOADS}/#{f}"
       download file_target => file_source
 
       # depend on downloads directory
-      file file_target => "downloads"
+      file file_target => RubyInstaller::DOWNLOADS
 
       # download task need these files as pre-requisites
       task :download => file_target
     end
 
-    task :checkout => "downloads" do
+    task :checkout => RubyInstaller::DOWNLOADS do
       cd RubyInstaller::ROOT do
         # If is there already a checkout, update instead of checkout
         if File.exist?(File.join(RubyInstaller::ROOT, package.checkout_target, '.git'))
@@ -49,7 +49,7 @@ namespace(:tools) do
       # use the checkout copy instead of the packaged file
       unless ENV['CHECKOUT']
         files.each { |f|
-          extract(File.join(RubyInstaller::ROOT, f), package.target)
+          extract(f, package.target)
         }
       else
         cp_r(package.checkout_target, File.join(RubyInstaller::ROOT, 'sandbox'), :verbose => true, :remove_destination => true)


### PR DESCRIPTION
I added a way to specify the folder to place downloaded files.

You can share a "downloads" folder with multiple windows installer build instances
without copying from one instance to another.

  rake DOWNLOADS="c:\downloads" # specify the folder to place downloaded files, absolute/relative

In addition above, I added the ability to handle dependency files 
more properly in multi-toolchain.

Download a set of dependency files from distinguished URL path
and store them under the "downloads" sub-directory separately.

config/compilers/mingw64.rb is just a sample.
You'll fail in downloading the dependency files, since there aren't such files.

:knap_path value is used for separation.
